### PR TITLE
添加工作单元手动关闭

### DIFF
--- a/FreeSql.DbContext/UnitOfWork/IUnitOfWork.cs
+++ b/FreeSql.DbContext/UnitOfWork/IUnitOfWork.cs
@@ -12,8 +12,21 @@ namespace FreeSql {
 
 		IsolationLevel? IsolationLevel { get; set; }
 
-		void Commit();
+        /// <summary>
+        /// 是否启用工作单元
+        /// </summary>
+        bool Enable { get; }
+
+        void Commit();
 
 		void Rollback();
-	}
+
+        /// <summary>
+        /// 禁用工作单元
+        /// <exception cref="Exception"></exception>
+        /// <para></para>
+        /// 若已开启事务（已有Insert/Update/Delete操作），调用此方法将发生异常，建议在执行逻辑前调用
+        /// </summary>
+        void Disable();
+    }
 }

--- a/FreeSql.DbContext/UnitOfWork/UnitOfWork.cs
+++ b/FreeSql.DbContext/UnitOfWork/UnitOfWork.cs
@@ -23,12 +23,35 @@ namespace FreeSql {
 			_conn = null;
 		}
 
-		public IsolationLevel? IsolationLevel { get; set; }
+
+        /// <summary>
+        /// 是否启用工作单元
+        /// </summary>
+        public bool Enable { get; private set; } = true;
+
+        /// <summary>
+        /// 禁用工作单元
+        /// <exception cref="Exception"></exception>
+        /// <para></para>
+        /// 若已开启事务（已有Insert/Update/Delete操作），调用此方法将发生异常，建议在执行逻辑前调用
+        /// </summary>
+        public void Disable()
+        {
+            if (_tran != null)
+            {
+                throw new Exception("已开启事务，不能禁用工作单元");
+            }
+
+            Enable = false;
+        }
+
+        public IsolationLevel? IsolationLevel { get; set; }
 
 		public DbTransaction GetOrBeginTransaction(bool isCreate = true) {
 
 			if (_tran != null) return _tran;
 			if (isCreate == false) return null;
+            if (!Enable) return null;
 			if (_conn != null) _fsql.Ado.MasterPool.Return(_conn);
 
 			_conn = _fsql.Ado.MasterPool.Get();


### PR DESCRIPTION
调用此方法后，工作单元将失效，即不会开启事务，即便仓储赋值了 Repo.UnitOfWork=uow 也不会开启事务。

添加此方法不会影响以前代码的正常使用。

在已有 Insert/Update/Delete 以后调用此方法将会抛出异常，因为这时已经开启事务，不能使工作单元生效。

应用场景：类似于ABP的在应用逻辑层的自动工作单元（自动开启事务），利用AOP在执行方法以前开启工作单元，执行完毕以后自动提交，但是此功能可以设置Attribute来进行关闭。本方法就是能是AOP在执行方法前通过检测Attribute来进行关闭工作单元。因为目前需要给每个仓储赋值工作单元过于麻烦，所以在依赖注入仓储时，可以封装默认就注入工作单元，类似于

````csharp
class Repo<T>:BaseRepo<T>
{
    public Repo(IUnitOfWork uow)
    {
        this.UnitOfWork=uow
    }
}
````
这样实际上在使用仓储的时候就赋值了工作单元，可以理解为默认开启了工作单元，但是我们肯定有不需要开启工作单元的情况，所以设置一个关闭的方法。

````csharp
class AppService
{
    private readonly Repo<T> _repo
    public AppService(Repo<T> repo)
    {
        _repo=repo
    }

   [UnitOfWork(false)] // AOP 调用 uow.Disable()
    public void Business()
    {
        _repo.Insert(xxx)
    }

    //因为在依赖注入已经为仓储赋值uow 所以，uow默认开启
    public void Business2()
    {
        _repo.Insert(xxx)
    }
   //AOP uow.Commit
}
````


单元测试已通过：

![image](https://user-images.githubusercontent.com/13200155/57460161-2e18e880-72a7-11e9-9cd4-24927a1d918c.png)
